### PR TITLE
Fix build with gcc 10

### DIFF
--- a/jpeg/ejpeg.h
+++ b/jpeg/ejpeg.h
@@ -32,4 +32,4 @@
 #define IMG_FORMAT_411  0x05   /* Three-component 4:1:1  image */
 
 JPEGEXPORT
-int No_JPEG_Header_Flag;
+extern int No_JPEG_Header_Flag;


### PR DESCRIPTION
gcc 10 uses `-fno-common` by default. It means that global variables must be declared with the `extern` keyword, otherwise a link error will occur.

Explanation:
https://gcc.gnu.org/gcc-10/porting_to.html#common